### PR TITLE
fix: positional arguments + mkdirall fixes + other stuff

### DIFF
--- a/cmd/layer/activate/activate.go
+++ b/cmd/layer/activate/activate.go
@@ -13,7 +13,7 @@ import (
 )
 
 var ActivateCmd = &cobra.Command{
-	Use:   "activate",
+	Use:   "activate [TARGET]",
 	Short: "Activate a layer and refresh sysext",
 	Long:  `Activate a selected layer (symlink it to /var/lib/extensions) and refresh the system extensions store.`,
 	RunE:  activateCmd,

--- a/cmd/layer/add/add.go
+++ b/cmd/layer/add/add.go
@@ -21,7 +21,7 @@ import (
 )
 
 var AddCmd = &cobra.Command{
-	Use:   "add",
+	Use:   "add [TARGET]",
 	Short: "Add a built layer onto the cache and activate it",
 	Long:  `Copy TARGET over to cache-dir as a blob with the TARGET's sha256 as the filename`,
 	RunE:  addCmd,

--- a/cmd/layer/deactivate/deactivate.go
+++ b/cmd/layer/deactivate/deactivate.go
@@ -10,7 +10,7 @@ import (
 )
 
 var DeactivateCmd = &cobra.Command{
-	Use:   "deactivate",
+	Use:   "deactivate [TARGET]",
 	Short: "Deactivate a layer and refresh sysext",
 	Long:  `Deativate a selected layer (unsymlink it from /var/lib/extensions) and refresh the system extensions store.`,
 	RunE:  deactivateCmd,

--- a/cmd/layer/list/list.go
+++ b/cmd/layer/list/list.go
@@ -16,15 +16,15 @@ import (
 )
 
 var ListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   "list [LAYER/HASH]",
 	Short: "List layers in cache and in activation",
-	Long:  `List layers in the cache directory, their blobs and symlinks in their cache`,
+	Long:  `List layers in the cache directory, their blobs and symlinks in their cache. Can also single check a layer or hash specified.`,
 	RunE:  listCmd,
 }
 
 var (
 	fLayer     *string
-	fQuiet     *bool
+	fCheck     *bool
 	fVerbose   *bool
 	fActivated *bool
 	fSeparator *string
@@ -34,7 +34,7 @@ var (
 func init() {
 	fVerbose = ListCmd.Flags().BoolP("verbose", "v", false, "List all layer's hashes")
 	fLayer = ListCmd.Flags().StringP("layer", "l", "", "List hashes inside the target layer")
-	fQuiet = ListCmd.Flags().BoolP("quiet", "q", false, "Only check for layer or hash existence instead of listing")
+	fCheck = ListCmd.Flags().BoolP("check", "c", false, "Only check for layer or hash existence instead of listing")
 	fActivated = ListCmd.Flags().Bool("activated", false, "List only activated layers")
 	fSeparator = ListCmd.Flags().StringP("separator", "s", "\n", "Separator for listing things like arrays")
 	fLogOnly = ListCmd.Flags().Bool("log", false, "Do not make a table, just log everything")
@@ -53,7 +53,7 @@ func listCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if *fQuiet {
+	if *fCheck {
 		if len(args) < 1 {
 			return internal.NewPositionalError("LAYER")
 		}

--- a/cmd/mount/extensions/extensions.go
+++ b/cmd/mount/extensions/extensions.go
@@ -2,7 +2,9 @@ package extensions
 
 import (
 	"fmt"
+	"log/slog"
 	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/ublue-os/bext/internal"
@@ -41,6 +43,7 @@ func extensionsCmd(cmd *cobra.Command, args []string) error {
 		command = append(command, "merge")
 	}
 
+	slog.Debug("Running systemd-sysext", slog.String("command", strings.Join(command, " ")))
 	out, err := exec.Command("systemd-sysext", command...).Output()
 	if err != nil {
 		fmt.Printf("%s\n", out)


### PR DESCRIPTION
This PR should fix most if not all bugs that we mentioned when testing bext for the first time on discord, and also adds verboser logging for every affected file.

This also removes the `--refresh` flag from `bext mount store` since refreshing is required whenever mounting the store, and also I dont know how to check if a directory is a mountpoint ideomatically and in a guaranteed way

Fixes #31 too.
